### PR TITLE
use only libcurl-4 name with version suffix

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,7 +5,7 @@ using BinDeps
 @windows_only begin
 # note that there is a 32-bit version of libcurl.dll
 # included with Git, which will not work with 64 bit Julia
-libcurl = library_dependency("libcurl", aliases = ["libcurl-4"])
+libcurl = library_dependency("libcurl-4")
 using WinRPM
 provides(WinRPM.RPM, "libcurl", libcurl, os = :Windows)
 end


### PR DESCRIPTION
to avoid picking up the version that comes with Git
