### PR TITLE
Change the return types of functions that returned nothing from None …

### DIFF
--- a/src/lC_curl_h.jl
+++ b/src/lC_curl_h.jl
@@ -5,19 +5,19 @@
 @c Cint curl_strnequal (Ptr{Uint8}, Ptr{Uint8}, size_t) libcurl
 @c CURLFORMcode curl_formadd (Ptr{Ptr{Void}}, Ptr{Ptr{Void}}) libcurl
 @c Cint curl_formget (Ptr{Void}, Ptr{Void}, curl_formget_callback) libcurl
-@c None curl_formfree (Ptr{Void},) libcurl
+@c Void curl_formfree (Ptr{Void},) libcurl
 @c Ptr{Uint8} curl_getenv (Ptr{Uint8},) libcurl
 @c Ptr{Uint8} curl_version () libcurl
 @c Ptr{Uint8} curl_easy_escape (Ptr{CURL}, Ptr{Uint8}, Cint) libcurl
 @c Ptr{Uint8} curl_escape (Ptr{Uint8}, Cint) libcurl
 @c Ptr{Uint8} curl_easy_unescape (Ptr{CURL}, Ptr{Uint8}, Cint, Ptr{Cint}) libcurl
 @c Ptr{Uint8} curl_unescape (Ptr{Uint8}, Cint) libcurl
-@c None curl_free (Ptr{Void},) libcurl
+@c Void curl_free (Ptr{Void},) libcurl
 @c CURLcode curl_global_init (Cint,) libcurl
 @c CURLcode curl_global_init_mem (Cint, curl_malloc_callback, curl_free_callback, curl_realloc_callback, curl_strdup_callback, curl_calloc_callback) libcurl
-@c None curl_global_cleanup () libcurl
+@c Void curl_global_cleanup () libcurl
 @c Ptr{Void} curl_slist_append (Ptr{Void}, Ptr{Uint8}) libcurl
-@c None curl_slist_free_all (Ptr{Void},) libcurl
+@c Void curl_slist_free_all (Ptr{Void},) libcurl
 @c time_t curl_getdate (Ptr{Uint8}, Ptr{time_t}) libcurl
 @c Ptr{CURLSH} curl_share_init () libcurl
 @c CURLSHcode curl_share_setopt (Ptr{CURLSH}, CURLSHoption) libcurl
@@ -29,10 +29,10 @@
 @c Ptr{CURL} curl_easy_init () libcurl
 @c CURLcode curl_easy_setopt (Ptr{CURL}, CURLoption) libcurl
 @c CURLcode curl_easy_perform (Ptr{CURL},) libcurl
-@c None curl_easy_cleanup (Ptr{CURL},) libcurl
+@c Void curl_easy_cleanup (Ptr{CURL},) libcurl
 @c CURLcode curl_easy_getinfo (Ptr{CURL}, CURLINFO) libcurl
 @c Ptr{CURL} curl_easy_duphandle (Ptr{CURL},) libcurl
-@c None curl_easy_reset (Ptr{CURL},) libcurl
+@c Void curl_easy_reset (Ptr{CURL},) libcurl
 @c CURLcode curl_easy_recv (Ptr{CURL}, Ptr{Void}, size_t, Ptr{size_t}) libcurl
 @c CURLcode curl_easy_send (Ptr{CURL}, Ptr{Void}, size_t, Ptr{size_t}) libcurl
 @c Ptr{CURLM} curl_multi_init () libcurl
@@ -48,5 +48,5 @@
 @c CURLMcode curl_multi_socket_all (Ptr{CURLM}, Ptr{Cint}) libcurl
 @c CURLMcode curl_multi_timeout (Ptr{CURLM}, Ptr{Cint}) libcurl
 @c CURLMcode curl_multi_setopt (Ptr{CURLM}, CURLMoption) libcurl
-@c CURLMcode curl_multi_assign (Ptr{CURLM}, curl_socket_t, Ptr{None}) libcurl
+@c CURLMcode curl_multi_assign (Ptr{CURLM}, curl_socket_t, Ptr{Void}) libcurl
 


### PR DESCRIPTION
…to Void

We were having issues trying to run tests with this command `julia --color=yes --check-bounds=yes --inline=yes -e 'Pkg.test("FTPClient"; coverage=true)`. The tests would segfault as soon as we tried to run `curl_easy_cleanup`. Also notice that if we removed `coverage=true`, tests would run with no errors.

While looking into this issue, we noticed that the following lines has some strange behaviour.
```
using LibCURL

function success()
    curl = Ptr{CURL}(curl_easy_init())
    curl == C_NULL
    curl_easy_cleanup(curl); println("\nhello, world")
end

function fail()
    curl = Ptr{CURL}(curl_easy_init())
    curl == C_NULL
    curl_easy_cleanup(curl)
end
```

trying to run `fail()` would result in a segfault, but `success()` would run with no errors.

We having discovered that `curl_easy_cleanup` was returning `None`, which is equivalent to `Union{}`, but `curl_easy_cleanup` isn't suppose to return anything. So we went and changed all `None` return to `Void`. 

With these changes, our tests running with coverage had no problems and in the code above both `success()` and `fail()` will work.