### PR TITLE
Don't checkout HTTPClient when running tests

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 HTTPClient
+JSON

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,4 @@ using LibCURL
 
 # For lack of anything better, just run HTTPClient's tests.
 # They should exercise a large number of LibCURL features.
-# Until HTTPClient is bumped, that requires using master of
-# HTTPClient. Careful running this test locally!
-Pkg.checkout("HTTPClient")
 Pkg.test("HTTPClient",coverage=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,4 +2,4 @@ using LibCURL
 
 # For lack of anything better, just run HTTPClient's tests.
 # They should exercise a large number of LibCURL features.
-Pkg.test("HTTPClient",coverage=true)
+include(Pkg.dir("HTTPClient","test","runtests.jl"))


### PR DESCRIPTION
This kind of stuff belongs in `.travis.yml`, not `test/runtests.jl`.