### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,18 @@ curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1)
 
 
 # setup the callback function to recv data
-function curl_read_cb(curlbuf::Ptr{Void}, s::Csize_t, n::Csize_t, p_ctxt::Ptr{Void})
+function curl_write_cb(curlbuf::Ptr{Void}, s::Csize_t, n::Csize_t, p_ctxt::Ptr{Void})
     sz = s * n
     data = Array(UInt8, sz)
-
-    ccall(:memcpy, Ptr{Void}, (Ptr{Void}, Ptr{Void}, UInt64), curlbuf, data, sz)
-    println("recd: ", bytestring(data))
-
+    
+    ccall(:memcpy, Ptr{Void}, (Ptr{Void}, Ptr{Void}, UInt64), data, curlbuf, sz)
+    println("recd: ", String(copy(data)))
+    
     sz::Csize_t
 end
 
-c_curl_read_cb = cfunction(curl_read_cb, Csize_t, (Ptr{Void}, Csize_t, Csize_t, Ptr{Void}))
-curl_easy_setopt(curl, CURLOPT_READFUNCTION, c_curl_read_cb)
+c_curl_write_cb = cfunction(curl_write_cb, Csize_t, (Ptr{Void}, Csize_t, Csize_t, Ptr{Void}))
+curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, c_curl_write_cb)
 
 
 # execute the query


### PR DESCRIPTION
It seems the example in the readme should use `CURLOPT_WRITEFUNCTION` instead of `CURLOPT_READFUNCTION`.  Using the readme as is could cause an unsuspecting user to post random bytes of one's memory via the uninitialized `data` array.

The text shown at the REPL as a result of the current readme is simply text that is printed to STDOUT by the C library (not the result of `curl_read_cb`) as can be verified by the fact that "recd: " is never printed.

See:
https://curl.haxx.se/libcurl/c/CURLOPT_WRITEFUNCTION.html
https://curl.haxx.se/libcurl/c/CURLOPT_READFUNCTION.html