### PR TITLE
Mostly fix Julia 1.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /*.tar.gz
 /tmp
 /dist
+/deps/build.log
 
 /julia
 /julia-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,20 @@ os:
     - linux
     - osx
 julia:
+    - 0.6
     - 0.7
     - 1.0
     - nightly
 notifications:
     email: false
-sudo: false
-script:
-    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'import Pkg; Pkg.clone(pwd())'
-    - julia -e 'import Pkg; Pkg.test("LibCURL", coverage=true)'
+# script:
+#     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#     - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("LibCURL"); Pkg.test("LibCURL"; coverage=true)'
 after_success:
-    - julia -e 'import Pkg; cd(Pkg.dir("LibCURL")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+    - |
+    julia -e '
+      VERSION >= v"0.7.0-DEV.3656" && using Pkg
+      VERSION >= v"0.7.0-DEV.5183" || cd(Pkg.dir("LibCURL"))
+      Pkg.add("Coverage"); using Coverage
+      Codecov.submit(process_folder())'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,16 @@ os:
     - linux
     - osx
 julia:
-    - 0.4
-    - 0.5
-    - 0.6
+    - 0.7
+    - 1.0
     - nightly
 notifications:
     email: false
 sudo: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.clone(pwd())'
-    - julia -e 'Pkg.test("LibCURL", coverage=true)'
+    - julia -e 'import Pkg; Pkg.clone(pwd())'
+    - julia -e 'import Pkg; Pkg.test("LibCURL", coverage=true)'
 after_success:
-    - julia -e 'cd(Pkg.dir("LibCURL")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+    - julia -e 'import Pkg; cd(Pkg.dir("LibCURL")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.7
 BinDeps
 Compat 0.8
 @windows WinRPM

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.7
+julia 0.6
 BinDeps
-Compat 0.8
+Compat 0.41
 @windows WinRPM

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,9 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/1.0/julia-1.0-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,12 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/1.0/julia-1.0-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1.0
+  - julia_version: latest
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
 
 branches:
   only:
@@ -19,19 +20,13 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
+  - C:\julia\bin\julia -e "versioninfo(); import Pkg;
       Pkg.clone(pwd(), \"LibCURL\"); Pkg.build(\"LibCURL\")"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"LibCURL\")"
+  - C:\julia\bin\julia -e "import Pkg; Pkg.test(\"LibCURL\")"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   matrix:
+  - julia_version: 0.6
   - julia_version: 0.7
   - julia_version: 1.0
   - julia_version: latest
@@ -23,10 +24,9 @@ install:
   - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\julia\bin\julia -e "versioninfo(); import Pkg;
-      Pkg.clone(pwd(), \"LibCURL\"); Pkg.build(\"LibCURL\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\julia\bin\julia -e "import Pkg; Pkg.test(\"LibCURL\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,9 +1,9 @@
 using BinDeps
-import Compat: is_windows
+import Compat.Sys: iswindows
 
 @BinDeps.setup
 
-if is_windows()
+if iswindows()
     # note that there is a 32-bit version of libcurl.dll
     # included with Git, which will not work with 64 bit Julia
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,9 +1,9 @@
 using BinDeps
-import Compat.Sys: iswindows
+import Compat: Sys
 
 @BinDeps.setup
 
-if iswindows()
+if Sys.iswindows()
     # note that there is a 32-bit version of libcurl.dll
     # included with Git, which will not work with 64 bit Julia
 

--- a/src/LibCURL.jl
+++ b/src/LibCURL.jl
@@ -2,7 +2,7 @@ isdefined(Base, :__precompile__) && __precompile__()
 
 module LibCURL
 
-import Compat: is_windows
+import Compat.Sys: iswindows
 
 const time_t = Int
 const size_t = Csize_t
@@ -11,7 +11,7 @@ const curl_off_t = Int64
 include("lC_exports_h.jl")
 include("lC_common_h.jl")
 
-const libcurl = if is_windows()
+const libcurl = if iswindows()
     Pkg.dir("WinRPM","deps","usr","$(Sys.ARCH)-w64-mingw32","sys-root","mingw","bin","libcurl-4")
 else
     "libcurl"
@@ -19,17 +19,17 @@ end
 
 include("lC_curl_h.jl")
 
-curl_easy_setopt(handle, opt, ptrval::Array) = ccall((:curl_easy_setopt, libcurl), CURLcode, (Ptr{CURL}, CURLoption, Ptr{Void}), handle, opt, pointer(ptrval))
+curl_easy_setopt(handle, opt, ptrval::Array) = ccall((:curl_easy_setopt, libcurl), CURLcode, (Ptr{CURL}, CURLoption, Ptr{Nothing}), handle, opt, pointer(ptrval))
 curl_easy_setopt(handle, opt, ptrval::Integer) = ccall((:curl_easy_setopt, libcurl), CURLcode, (Ptr{CURL}, CURLoption, Clong), handle, opt, ptrval)
-curl_easy_setopt{T}(handle, opt, ptrval::Ptr{T}) = ccall((:curl_easy_setopt, libcurl), CURLcode, (Ptr{CURL}, CURLoption, Ptr{T}), handle, opt, ptrval)
+curl_easy_setopt(handle, opt, ptrval::Ptr{T}) where {T} = ccall((:curl_easy_setopt, libcurl), CURLcode, (Ptr{CURL}, CURLoption, Ptr{T}), handle, opt, ptrval)
 curl_easy_setopt(handle, opt, ptrval::AbstractString) = ccall((:curl_easy_setopt, libcurl), CURLcode, (Ptr{CURL}, CURLoption, Ptr{UInt8}), handle, opt, ptrval)
 
-curl_multi_setopt(handle, opt, ptrval::Array) = ccall((:curl_multi_setopt, libcurl), CURLMcode, (Ptr{CURLM}, CURLMoption, Ptr{Void}), handle, opt, pointer(ptrval))
+curl_multi_setopt(handle, opt, ptrval::Array) = ccall((:curl_multi_setopt, libcurl), CURLMcode, (Ptr{CURLM}, CURLMoption, Ptr{Nothing}), handle, opt, pointer(ptrval))
 curl_multi_setopt(handle, opt, ptrval::Integer) = ccall((:curl_multi_setopt, libcurl), CURLMcode, (Ptr{CURLM}, CURLMoption, Clong), handle, opt, ptrval)
-curl_multi_setopt{T}(handle, opt, ptrval::Ptr{T}) = ccall((:curl_multi_setopt, libcurl), CURLMcode, (Ptr{CURLM}, CURLMoption, Ptr{T}), handle, opt, ptrval)
+curl_multi_setopt(handle, opt, ptrval::T) where {T} = ccall((:curl_multi_setopt, libcurl), CURLMcode, (Ptr{CURLM}, CURLMoption, T), handle, opt, ptrval)
 curl_multi_setopt(handle, opt, ptrval::AbstractString) = ccall((:curl_multi_setopt, libcurl), CURLMcode, (Ptr{CURLM}, CURLMoption, Ptr{UInt8}), handle, opt, ptrval)
 
-curl_easy_getinfo(handle, opt, ptrval::Array) = ccall((:curl_easy_getinfo, libcurl), CURLcode, (Ptr{CURL}, CURLoption, Ptr{Void}), handle, opt, pointer(ptrval))
+curl_easy_getinfo(handle, opt, ptrval::Array) = ccall((:curl_easy_getinfo, libcurl), CURLcode, (Ptr{CURL}, CURLoption, Ptr{Nothing}), handle, opt, pointer(ptrval))
 curl_easy_getinfo(handle, opt, ptrval::AbstractString) = ccall((:curl_easy_getinfo, libcurl), CURLcode, (Ptr{CURL}, CURLoption, Ptr{UInt8}), handle, opt, ptrval)
 
 include("lC_defines_h.jl")

--- a/src/LibCURL.jl
+++ b/src/LibCURL.jl
@@ -12,7 +12,13 @@ include("lC_exports_h.jl")
 include("lC_common_h.jl")
 
 const libcurl = if Sys.iswindows()
-    Pkg.dir("WinRPM","deps","usr","$(Sys.ARCH)-w64-mingw32","sys-root","mingw","bin","libcurl-4")
+    dir = if VERSION >= v"0.7"
+        import WinRPM
+        joinpath(dirname(pathof(WinRPM)), "..")
+    else
+        Pkg.dir("WinRPM")
+    end
+    joinpath(dir,"deps","usr","$(Base.Sys.ARCH)-w64-mingw32","sys-root","mingw","bin","libcurl-4")
 else
     "libcurl"
 end

--- a/src/LibCURL.jl
+++ b/src/LibCURL.jl
@@ -1,8 +1,8 @@
-isdefined(Base, :__precompile__) && __precompile__()
+VERSION < v"0.7.0-beta2.199" && __precompile__()
 
 module LibCURL
 
-import Compat.Sys: iswindows
+import Compat: Sys, Cvoid
 
 const time_t = Int
 const size_t = Csize_t
@@ -11,7 +11,7 @@ const curl_off_t = Int64
 include("lC_exports_h.jl")
 include("lC_common_h.jl")
 
-const libcurl = if iswindows()
+const libcurl = if Sys.iswindows()
     Pkg.dir("WinRPM","deps","usr","$(Sys.ARCH)-w64-mingw32","sys-root","mingw","bin","libcurl-4")
 else
     "libcurl"
@@ -26,7 +26,7 @@ curl_easy_setopt(handle, opt, ptrval::AbstractString) = ccall((:curl_easy_setopt
 
 curl_multi_setopt(handle, opt, ptrval::Array) = ccall((:curl_multi_setopt, libcurl), CURLMcode, (Ptr{CURLM}, CURLMoption, Ptr{Cvoid}), handle, opt, pointer(ptrval))
 curl_multi_setopt(handle, opt, ptrval::Integer) = ccall((:curl_multi_setopt, libcurl), CURLMcode, (Ptr{CURLM}, CURLMoption, Clong), handle, opt, ptrval)
-curl_multi_setopt(handle, opt, ptrval::T) where {T} = ccall((:curl_multi_setopt, libcurl), CURLMcode, (Ptr{CURLM}, CURLMoption, T), handle, opt, ptrval)
+curl_multi_setopt(handle, opt, ptrval::Ptr{T}) where {T} = ccall((:curl_multi_setopt, libcurl), CURLMcode, (Ptr{CURLM}, CURLMoption, Ptr{T}), handle, opt, ptrval)
 curl_multi_setopt(handle, opt, ptrval::AbstractString) = ccall((:curl_multi_setopt, libcurl), CURLMcode, (Ptr{CURLM}, CURLMoption, Ptr{UInt8}), handle, opt, ptrval)
 
 curl_easy_getinfo(handle, opt, ptrval::Array) = ccall((:curl_easy_getinfo, libcurl), CURLcode, (Ptr{CURL}, CURLoption, Ptr{Cvoid}), handle, opt, pointer(ptrval))

--- a/src/LibCURL.jl
+++ b/src/LibCURL.jl
@@ -19,17 +19,17 @@ end
 
 include("lC_curl_h.jl")
 
-curl_easy_setopt(handle, opt, ptrval::Array) = ccall((:curl_easy_setopt, libcurl), CURLcode, (Ptr{CURL}, CURLoption, Ptr{Nothing}), handle, opt, pointer(ptrval))
+curl_easy_setopt(handle, opt, ptrval::Array) = ccall((:curl_easy_setopt, libcurl), CURLcode, (Ptr{CURL}, CURLoption, Ptr{Cvoid}), handle, opt, pointer(ptrval))
 curl_easy_setopt(handle, opt, ptrval::Integer) = ccall((:curl_easy_setopt, libcurl), CURLcode, (Ptr{CURL}, CURLoption, Clong), handle, opt, ptrval)
 curl_easy_setopt(handle, opt, ptrval::Ptr{T}) where {T} = ccall((:curl_easy_setopt, libcurl), CURLcode, (Ptr{CURL}, CURLoption, Ptr{T}), handle, opt, ptrval)
 curl_easy_setopt(handle, opt, ptrval::AbstractString) = ccall((:curl_easy_setopt, libcurl), CURLcode, (Ptr{CURL}, CURLoption, Ptr{UInt8}), handle, opt, ptrval)
 
-curl_multi_setopt(handle, opt, ptrval::Array) = ccall((:curl_multi_setopt, libcurl), CURLMcode, (Ptr{CURLM}, CURLMoption, Ptr{Nothing}), handle, opt, pointer(ptrval))
+curl_multi_setopt(handle, opt, ptrval::Array) = ccall((:curl_multi_setopt, libcurl), CURLMcode, (Ptr{CURLM}, CURLMoption, Ptr{Cvoid}), handle, opt, pointer(ptrval))
 curl_multi_setopt(handle, opt, ptrval::Integer) = ccall((:curl_multi_setopt, libcurl), CURLMcode, (Ptr{CURLM}, CURLMoption, Clong), handle, opt, ptrval)
 curl_multi_setopt(handle, opt, ptrval::T) where {T} = ccall((:curl_multi_setopt, libcurl), CURLMcode, (Ptr{CURLM}, CURLMoption, T), handle, opt, ptrval)
 curl_multi_setopt(handle, opt, ptrval::AbstractString) = ccall((:curl_multi_setopt, libcurl), CURLMcode, (Ptr{CURLM}, CURLMoption, Ptr{UInt8}), handle, opt, ptrval)
 
-curl_easy_getinfo(handle, opt, ptrval::Array) = ccall((:curl_easy_getinfo, libcurl), CURLcode, (Ptr{CURL}, CURLoption, Ptr{Nothing}), handle, opt, pointer(ptrval))
+curl_easy_getinfo(handle, opt, ptrval::Array) = ccall((:curl_easy_getinfo, libcurl), CURLcode, (Ptr{CURL}, CURLoption, Ptr{Cvoid}), handle, opt, pointer(ptrval))
 curl_easy_getinfo(handle, opt, ptrval::AbstractString) = ccall((:curl_easy_getinfo, libcurl), CURLcode, (Ptr{CURL}, CURLoption, Ptr{UInt8}), handle, opt, ptrval)
 
 include("lC_defines_h.jl")

--- a/src/lC_common_h.jl
+++ b/src/lC_common_h.jl
@@ -13,8 +13,8 @@ end
 
 @ctypedef CURL Union{}
 @ctypedef curl_socket_t Int32
-type curl_httppost
-  next::Ptr{Void}
+mutable struct curl_httppost
+  next::Ptr{Nothing}
   name::Ptr{UInt8}
   namelength::Int32
   contents::Ptr{UInt8}
@@ -22,14 +22,14 @@ type curl_httppost
   buffer::Ptr{UInt8}
   bufferlength::Int32
   contenttype::Ptr{UInt8}
-  contentheader::Ptr{Void}
-  more::Ptr{Void}
+  contentheader::Ptr{Nothing}
+  more::Ptr{Nothing}
   flags::Int32
   showfilename::Ptr{UInt8}
-  userp::Ptr{Void}
+  userp::Ptr{Nothing}
 end
-@ctypedef curl_progress_callback Ptr{Void}
-@ctypedef curl_write_callback Ptr{Void}
+@ctypedef curl_progress_callback Ptr{Nothing}
+@ctypedef curl_write_callback Ptr{Nothing}
 # enum curlfiletype
 const CURLFILETYPE_FILE = 0
 const CURLFILETYPE_DIRECTORY = 1
@@ -42,7 +42,7 @@ const CURLFILETYPE_DOOR = 7
 const CURLFILETYPE_UNKNOWN = 8
 # end
 @ctypedef curlfiletype Int32
-type curl_fileinfo
+mutable struct curl_fileinfo
   filename::Ptr{UInt8}
   filetype::curlfiletype
   time::time_t
@@ -51,32 +51,32 @@ type curl_fileinfo
   gid::Int32
   size::curl_off_t
   hardlinks::Int32
-  strings::Void
+  strings::Nothing
   flags::UInt32
   b_data::Ptr{UInt8}
   b_size::size_t
   b_used::size_t
 end
-@ctypedef curl_chunk_bgn_callback Ptr{Void}
-@ctypedef curl_chunk_end_callback Ptr{Void}
-@ctypedef curl_fnmatch_callback Ptr{Void}
-@ctypedef curl_seek_callback Ptr{Void}
-@ctypedef curl_read_callback Ptr{Void}
+@ctypedef curl_chunk_bgn_callback Ptr{Nothing}
+@ctypedef curl_chunk_end_callback Ptr{Nothing}
+@ctypedef curl_fnmatch_callback Ptr{Nothing}
+@ctypedef curl_seek_callback Ptr{Nothing}
+@ctypedef curl_read_callback Ptr{Nothing}
 # enum curlsocktype
 const CURLSOCKTYPE_IPCXN = 0
 const CURLSOCKTYPE_LAST = 1
 # end
 @ctypedef curlsocktype Int32
-@ctypedef curl_sockopt_callback Ptr{Void}
-type curl_sockaddr
+@ctypedef curl_sockopt_callback Ptr{Nothing}
+struct curl_sockaddr
   family::Int32
   socktype::Int32
   protocol::Int32
   addrlen::UInt32
-  addr::Void
+  addr::Nothing
 end
-@ctypedef curl_opensocket_callback Ptr{Void}
-@ctypedef curl_closesocket_callback Ptr{Void}
+@ctypedef curl_opensocket_callback Ptr{Nothing}
+@ctypedef curl_closesocket_callback Ptr{Nothing}
 # enum curlioerr
 const CURLIOE_OK = 0
 const CURLIOE_UNKNOWNCMD = 1
@@ -90,12 +90,12 @@ const CURLIOCMD_RESTARTREAD = 1
 const CURLIOCMD_LAST = 2
 # end
 @ctypedef curliocmd Int32
-@ctypedef curl_ioctl_callback Ptr{Void}
-@ctypedef curl_malloc_callback Ptr{Void}
-@ctypedef curl_free_callback Ptr{Void}
-@ctypedef curl_realloc_callback Ptr{Void}
-@ctypedef curl_strdup_callback Ptr{Void}
-@ctypedef curl_calloc_callback Ptr{Void}
+@ctypedef curl_ioctl_callback Ptr{Nothing}
+@ctypedef curl_malloc_callback Ptr{Nothing}
+@ctypedef curl_free_callback Ptr{Nothing}
+@ctypedef curl_realloc_callback Ptr{Nothing}
+@ctypedef curl_strdup_callback Ptr{Nothing}
+@ctypedef curl_calloc_callback Ptr{Nothing}
 # enum curl_infotype
 const CURLINFO_TEXT = 0
 const CURLINFO_HEADER_IN = 1
@@ -107,7 +107,7 @@ const CURLINFO_SSL_DATA_OUT = 6
 const CURLINFO_END = 7
 # end
 @ctypedef curl_infotype Int32
-@ctypedef curl_debug_callback Ptr{Void}
+@ctypedef curl_debug_callback Ptr{Nothing}
 # enum CURLcode
 const CURLE_OK = 0
 const CURLE_UNSUPPORTED_PROTOCOL = 1
@@ -201,8 +201,8 @@ const CURLE_CHUNK_FAILED = 88
 const CURL_LAST = 89
 # end
 @ctypedef CURLcode Int32
-@ctypedef curl_conv_callback Ptr{Void}
-@ctypedef curl_ssl_ctx_callback Ptr{Void}
+@ctypedef curl_conv_callback Ptr{Nothing}
+@ctypedef curl_ssl_ctx_callback Ptr{Nothing}
 # enum curl_proxytype
 const CURLPROXY_HTTP = 0
 const CURLPROXY_HTTP_1_0 = 1
@@ -212,7 +212,7 @@ const CURLPROXY_SOCKS4A = 6
 const CURLPROXY_SOCKS5_HOSTNAME = 7
 # end
 @ctypedef curl_proxytype Int32
-type curl_khkey
+mutable struct curl_khkey
   key::Ptr{UInt8}
   len::size_t
   keytype::Int32
@@ -230,7 +230,7 @@ const CURLKHMATCH_MISMATCH = 1
 const CURLKHMATCH_MISSING = 2
 const CURLKHMATCH_LAST = 3
 # end
-@ctypedef curl_sshkeycallback Ptr{Void}
+@ctypedef curl_sshkeycallback Ptr{Nothing}
 # enum curl_usessl
 const CURLUSESSL_NONE = 0
 const CURLUSESSL_TRY = 1
@@ -520,7 +520,7 @@ const CURLFORM_STREAM = 19
 const CURLFORM_LASTENTRY = 20
 # end
 @ctypedef CURLformoption Int32
-type curl_forms
+mutable struct curl_forms
   option::CURLformoption
   value::Ptr{UInt8}
 end
@@ -536,14 +536,14 @@ const CURL_FORMADD_DISABLED = 7
 const CURL_FORMADD_LAST = 8
 # end
 @ctypedef CURLFORMcode Int32
-@ctypedef curl_formget_callback Ptr{Void}
-type curl_slist
+@ctypedef curl_formget_callback Ptr{Nothing}
+mutable struct curl_slist
   data::Ptr{UInt8}
-  next::Ptr{Void}
+  next::Ptr{Nothing}
 end
-type curl_certinfo
+mutable struct curl_certinfo
   num_of_certs::Int32
-  certinfo::Ptr{Ptr{Void}}
+  certinfo::Ptr{Ptr{Nothing}}
 end
 # enum CURLINFO
 const CURLINFO_NONE = 0
@@ -619,8 +619,8 @@ const CURL_LOCK_ACCESS_SINGLE = 2
 const CURL_LOCK_ACCESS_LAST = 3
 # end
 @ctypedef curl_lock_access Int32
-@ctypedef curl_lock_function Ptr{Void}
-@ctypedef curl_unlock_function Ptr{Void}
+@ctypedef curl_lock_function Ptr{Nothing}
+@ctypedef curl_unlock_function Ptr{Nothing}
 @ctypedef CURLSH Union{}
 # enum CURLSHcode
 const CURLSHE_OK = 0
@@ -650,7 +650,7 @@ const CURLVERSION_FOURTH = 3
 const CURLVERSION_LAST = 4
 # end
 @ctypedef CURLversion Int32
-type curl_version_info_data
+mutable struct curl_version_info_data
   age::CURLversion
   version::Ptr{UInt8}
   version_num::UInt32
@@ -685,13 +685,13 @@ const CURLMSG_DONE = 1
 const CURLMSG_LAST = 2
 # end
 @ctypedef CURLMSG Int32
-type CURLMsg
+mutable struct CURLMsg
   msg::CURLMSG
   easy_handle::Ptr{CURL}
-  data::Void
+  data::Nothing
 end
-@ctypedef curl_socket_callback Ptr{Void}
-@ctypedef curl_multi_timer_callback Ptr{Void}
+@ctypedef curl_socket_callback Ptr{Nothing}
+@ctypedef curl_multi_timer_callback Ptr{Nothing}
 # enum CURLMoption
 const CURLMOPT_SOCKETFUNCTION = 20001
 const CURLMOPT_SOCKETDATA = 10002

--- a/src/lC_common_h.jl
+++ b/src/lC_common_h.jl
@@ -14,7 +14,7 @@ end
 @ctypedef CURL Union{}
 @ctypedef curl_socket_t Int32
 mutable struct curl_httppost
-  next::Ptr{Nothing}
+  next::Ptr{Cvoid}
   name::Ptr{UInt8}
   namelength::Int32
   contents::Ptr{UInt8}
@@ -22,14 +22,14 @@ mutable struct curl_httppost
   buffer::Ptr{UInt8}
   bufferlength::Int32
   contenttype::Ptr{UInt8}
-  contentheader::Ptr{Nothing}
-  more::Ptr{Nothing}
+  contentheader::Ptr{Cvoid}
+  more::Ptr{Cvoid}
   flags::Int32
   showfilename::Ptr{UInt8}
-  userp::Ptr{Nothing}
+  userp::Ptr{Cvoid}
 end
-@ctypedef curl_progress_callback Ptr{Nothing}
-@ctypedef curl_write_callback Ptr{Nothing}
+@ctypedef curl_progress_callback Ptr{Cvoid}
+@ctypedef curl_write_callback Ptr{Cvoid}
 # enum curlfiletype
 const CURLFILETYPE_FILE = 0
 const CURLFILETYPE_DIRECTORY = 1
@@ -51,32 +51,32 @@ mutable struct curl_fileinfo
   gid::Int32
   size::curl_off_t
   hardlinks::Int32
-  strings::Nothing
+  strings::Cvoid
   flags::UInt32
   b_data::Ptr{UInt8}
   b_size::size_t
   b_used::size_t
 end
-@ctypedef curl_chunk_bgn_callback Ptr{Nothing}
-@ctypedef curl_chunk_end_callback Ptr{Nothing}
-@ctypedef curl_fnmatch_callback Ptr{Nothing}
-@ctypedef curl_seek_callback Ptr{Nothing}
-@ctypedef curl_read_callback Ptr{Nothing}
+@ctypedef curl_chunk_bgn_callback Ptr{Cvoid}
+@ctypedef curl_chunk_end_callback Ptr{Cvoid}
+@ctypedef curl_fnmatch_callback Ptr{Cvoid}
+@ctypedef curl_seek_callback Ptr{Cvoid}
+@ctypedef curl_read_callback Ptr{Cvoid}
 # enum curlsocktype
 const CURLSOCKTYPE_IPCXN = 0
 const CURLSOCKTYPE_LAST = 1
 # end
 @ctypedef curlsocktype Int32
-@ctypedef curl_sockopt_callback Ptr{Nothing}
+@ctypedef curl_sockopt_callback Ptr{Cvoid}
 struct curl_sockaddr
   family::Int32
   socktype::Int32
   protocol::Int32
   addrlen::UInt32
-  addr::Nothing
+  addr::Cvoid
 end
-@ctypedef curl_opensocket_callback Ptr{Nothing}
-@ctypedef curl_closesocket_callback Ptr{Nothing}
+@ctypedef curl_opensocket_callback Ptr{Cvoid}
+@ctypedef curl_closesocket_callback Ptr{Cvoid}
 # enum curlioerr
 const CURLIOE_OK = 0
 const CURLIOE_UNKNOWNCMD = 1
@@ -90,12 +90,12 @@ const CURLIOCMD_RESTARTREAD = 1
 const CURLIOCMD_LAST = 2
 # end
 @ctypedef curliocmd Int32
-@ctypedef curl_ioctl_callback Ptr{Nothing}
-@ctypedef curl_malloc_callback Ptr{Nothing}
-@ctypedef curl_free_callback Ptr{Nothing}
-@ctypedef curl_realloc_callback Ptr{Nothing}
-@ctypedef curl_strdup_callback Ptr{Nothing}
-@ctypedef curl_calloc_callback Ptr{Nothing}
+@ctypedef curl_ioctl_callback Ptr{Cvoid}
+@ctypedef curl_malloc_callback Ptr{Cvoid}
+@ctypedef curl_free_callback Ptr{Cvoid}
+@ctypedef curl_realloc_callback Ptr{Cvoid}
+@ctypedef curl_strdup_callback Ptr{Cvoid}
+@ctypedef curl_calloc_callback Ptr{Cvoid}
 # enum curl_infotype
 const CURLINFO_TEXT = 0
 const CURLINFO_HEADER_IN = 1
@@ -107,7 +107,7 @@ const CURLINFO_SSL_DATA_OUT = 6
 const CURLINFO_END = 7
 # end
 @ctypedef curl_infotype Int32
-@ctypedef curl_debug_callback Ptr{Nothing}
+@ctypedef curl_debug_callback Ptr{Cvoid}
 # enum CURLcode
 const CURLE_OK = 0
 const CURLE_UNSUPPORTED_PROTOCOL = 1
@@ -201,8 +201,8 @@ const CURLE_CHUNK_FAILED = 88
 const CURL_LAST = 89
 # end
 @ctypedef CURLcode Int32
-@ctypedef curl_conv_callback Ptr{Nothing}
-@ctypedef curl_ssl_ctx_callback Ptr{Nothing}
+@ctypedef curl_conv_callback Ptr{Cvoid}
+@ctypedef curl_ssl_ctx_callback Ptr{Cvoid}
 # enum curl_proxytype
 const CURLPROXY_HTTP = 0
 const CURLPROXY_HTTP_1_0 = 1
@@ -230,7 +230,7 @@ const CURLKHMATCH_MISMATCH = 1
 const CURLKHMATCH_MISSING = 2
 const CURLKHMATCH_LAST = 3
 # end
-@ctypedef curl_sshkeycallback Ptr{Nothing}
+@ctypedef curl_sshkeycallback Ptr{Cvoid}
 # enum curl_usessl
 const CURLUSESSL_NONE = 0
 const CURLUSESSL_TRY = 1
@@ -536,14 +536,14 @@ const CURL_FORMADD_DISABLED = 7
 const CURL_FORMADD_LAST = 8
 # end
 @ctypedef CURLFORMcode Int32
-@ctypedef curl_formget_callback Ptr{Nothing}
+@ctypedef curl_formget_callback Ptr{Cvoid}
 mutable struct curl_slist
   data::Ptr{UInt8}
-  next::Ptr{Nothing}
+  next::Ptr{Cvoid}
 end
 mutable struct curl_certinfo
   num_of_certs::Int32
-  certinfo::Ptr{Ptr{Nothing}}
+  certinfo::Ptr{Ptr{Cvoid}}
 end
 # enum CURLINFO
 const CURLINFO_NONE = 0
@@ -619,8 +619,8 @@ const CURL_LOCK_ACCESS_SINGLE = 2
 const CURL_LOCK_ACCESS_LAST = 3
 # end
 @ctypedef curl_lock_access Int32
-@ctypedef curl_lock_function Ptr{Nothing}
-@ctypedef curl_unlock_function Ptr{Nothing}
+@ctypedef curl_lock_function Ptr{Cvoid}
+@ctypedef curl_unlock_function Ptr{Cvoid}
 @ctypedef CURLSH Union{}
 # enum CURLSHcode
 const CURLSHE_OK = 0
@@ -688,10 +688,10 @@ const CURLMSG_LAST = 2
 mutable struct CURLMsg
   msg::CURLMSG
   easy_handle::Ptr{CURL}
-  data::Nothing
+  data::Cvoid
 end
-@ctypedef curl_socket_callback Ptr{Nothing}
-@ctypedef curl_multi_timer_callback Ptr{Nothing}
+@ctypedef curl_socket_callback Ptr{Cvoid}
+@ctypedef curl_multi_timer_callback Ptr{Cvoid}
 # enum CURLMoption
 const CURLMOPT_SOCKETFUNCTION = 20001
 const CURLMOPT_SOCKETDATA = 10002

--- a/src/lC_common_h.jl
+++ b/src/lC_common_h.jl
@@ -68,7 +68,7 @@ const CURLSOCKTYPE_LAST = 1
 # end
 @ctypedef curlsocktype Int32
 @ctypedef curl_sockopt_callback Ptr{Cvoid}
-struct curl_sockaddr
+mutable struct curl_sockaddr
   family::Int32
   socktype::Int32
   protocol::Int32

--- a/src/lC_curl_h.jl
+++ b/src/lC_curl_h.jl
@@ -3,21 +3,21 @@
 
 @c Cint curl_strequal (Ptr{UInt8}, Ptr{UInt8}) libcurl
 @c Cint curl_strnequal (Ptr{UInt8}, Ptr{UInt8}, size_t) libcurl
-@c CURLFORMcode curl_formadd (Ptr{Ptr{Nothing}}, Ptr{Ptr{Nothing}}) libcurl
-@c Cint curl_formget (Ptr{Nothing}, Ptr{Nothing}, curl_formget_callback) libcurl
-@c Nothing curl_formfree (Ptr{Nothing},) libcurl
+@c CURLFORMcode curl_formadd (Ptr{Ptr{Cvoid}}, Ptr{Ptr{Nothing}}) libcurl
+@c Cint curl_formget (Ptr{Cvoid}, Ptr{Nothing}, curl_formget_callback) libcurl
+@c Cvoid curl_formfree (Ptr{Nothing},) libcurl
 @c Ptr{UInt8} curl_getenv (Ptr{UInt8},) libcurl
 @c Ptr{UInt8} curl_version () libcurl
 @c Ptr{UInt8} curl_easy_escape (Ptr{CURL}, Ptr{UInt8}, Cint) libcurl
 @c Ptr{UInt8} curl_escape (Ptr{UInt8}, Cint) libcurl
 @c Ptr{UInt8} curl_easy_unescape (Ptr{CURL}, Ptr{UInt8}, Cint, Ptr{Cint}) libcurl
 @c Ptr{UInt8} curl_unescape (Ptr{UInt8}, Cint) libcurl
-@c Nothing curl_free (Ptr{Nothing},) libcurl
+@c Cvoid curl_free (Ptr{Nothing},) libcurl
 @c CURLcode curl_global_init (Cint,) libcurl
 @c CURLcode curl_global_init_mem (Cint, curl_malloc_callback, curl_free_callback, curl_realloc_callback, curl_strdup_callback, curl_calloc_callback) libcurl
-@c Nothing curl_global_cleanup () libcurl
-@c Ptr{Nothing} curl_slist_append (Ptr{Nothing}, Ptr{UInt8}) libcurl
-@c Nothing curl_slist_free_all (Ptr{Nothing},) libcurl
+@c Cvoid curl_global_cleanup () libcurl
+@c Ptr{Cvoid} curl_slist_append (Ptr{Nothing}, Ptr{UInt8}) libcurl
+@c Cvoid curl_slist_free_all (Ptr{Nothing},) libcurl
 @c time_t curl_getdate (Ptr{UInt8}, Ptr{time_t}) libcurl
 @c Ptr{CURLSH} curl_share_init () libcurl
 @c CURLSHcode curl_share_setopt (Ptr{CURLSH}, CURLSHoption) libcurl
@@ -29,12 +29,12 @@
 @c Ptr{CURL} curl_easy_init () libcurl
 @c CURLcode curl_easy_setopt (Ptr{CURL}, CURLoption) libcurl
 @c CURLcode curl_easy_perform (Ptr{CURL},) libcurl
-@c Nothing curl_easy_cleanup (Ptr{CURL},) libcurl
+@c Cvoid curl_easy_cleanup (Ptr{CURL},) libcurl
 @c CURLcode curl_easy_getinfo (Ptr{CURL}, CURLINFO) libcurl
 @c Ptr{CURL} curl_easy_duphandle (Ptr{CURL},) libcurl
-@c Nothing curl_easy_reset (Ptr{CURL},) libcurl
-@c CURLcode curl_easy_recv (Ptr{CURL}, Ptr{Nothing}, size_t, Ptr{size_t}) libcurl
-@c CURLcode curl_easy_send (Ptr{CURL}, Ptr{Nothing}, size_t, Ptr{size_t}) libcurl
+@c Cvoid curl_easy_reset (Ptr{CURL},) libcurl
+@c CURLcode curl_easy_recv (Ptr{CURL}, Ptr{Cvoid}, size_t, Ptr{size_t}) libcurl
+@c CURLcode curl_easy_send (Ptr{CURL}, Ptr{Cvoid}, size_t, Ptr{size_t}) libcurl
 @c Ptr{CURLM} curl_multi_init () libcurl
 @c CURLMcode curl_multi_add_handle (Ptr{CURLM}, Ptr{CURL}) libcurl
 @c CURLMcode curl_multi_remove_handle (Ptr{CURLM}, Ptr{CURL}) libcurl
@@ -48,5 +48,5 @@
 @c CURLMcode curl_multi_socket_all (Ptr{CURLM}, Ptr{Cint}) libcurl
 @c CURLMcode curl_multi_timeout (Ptr{CURLM}, Ptr{Cint}) libcurl
 @c CURLMcode curl_multi_setopt (Ptr{CURLM}, CURLMoption) libcurl
-@c CURLMcode curl_multi_assign (Ptr{CURLM}, curl_socket_t, Ptr{Nothing}) libcurl
+@c CURLMcode curl_multi_assign (Ptr{CURLM}, curl_socket_t, Ptr{Cvoid}) libcurl
 

--- a/src/lC_curl_h.jl
+++ b/src/lC_curl_h.jl
@@ -3,21 +3,21 @@
 
 @c Cint curl_strequal (Ptr{UInt8}, Ptr{UInt8}) libcurl
 @c Cint curl_strnequal (Ptr{UInt8}, Ptr{UInt8}, size_t) libcurl
-@c CURLFORMcode curl_formadd (Ptr{Ptr{Cvoid}}, Ptr{Ptr{Nothing}}) libcurl
-@c Cint curl_formget (Ptr{Cvoid}, Ptr{Nothing}, curl_formget_callback) libcurl
-@c Cvoid curl_formfree (Ptr{Nothing},) libcurl
+@c CURLFORMcode curl_formadd (Ptr{Ptr{Cvoid}}, Ptr{Ptr{Cvoid}}) libcurl
+@c Cint curl_formget (Ptr{Cvoid}, Ptr{Cvoid}, curl_formget_callback) libcurl
+@c Cvoid curl_formfree (Ptr{Cvoid},) libcurl
 @c Ptr{UInt8} curl_getenv (Ptr{UInt8},) libcurl
 @c Ptr{UInt8} curl_version () libcurl
 @c Ptr{UInt8} curl_easy_escape (Ptr{CURL}, Ptr{UInt8}, Cint) libcurl
 @c Ptr{UInt8} curl_escape (Ptr{UInt8}, Cint) libcurl
 @c Ptr{UInt8} curl_easy_unescape (Ptr{CURL}, Ptr{UInt8}, Cint, Ptr{Cint}) libcurl
 @c Ptr{UInt8} curl_unescape (Ptr{UInt8}, Cint) libcurl
-@c Cvoid curl_free (Ptr{Nothing},) libcurl
+@c Cvoid curl_free (Ptr{Cvoid},) libcurl
 @c CURLcode curl_global_init (Cint,) libcurl
 @c CURLcode curl_global_init_mem (Cint, curl_malloc_callback, curl_free_callback, curl_realloc_callback, curl_strdup_callback, curl_calloc_callback) libcurl
 @c Cvoid curl_global_cleanup () libcurl
-@c Ptr{Cvoid} curl_slist_append (Ptr{Nothing}, Ptr{UInt8}) libcurl
-@c Cvoid curl_slist_free_all (Ptr{Nothing},) libcurl
+@c Ptr{Cvoid} curl_slist_append (Ptr{Cvoid}, Ptr{UInt8}) libcurl
+@c Cvoid curl_slist_free_all (Ptr{Cvoid},) libcurl
 @c time_t curl_getdate (Ptr{UInt8}, Ptr{time_t}) libcurl
 @c Ptr{CURLSH} curl_share_init () libcurl
 @c CURLSHcode curl_share_setopt (Ptr{CURLSH}, CURLSHoption) libcurl

--- a/src/lC_curl_h.jl
+++ b/src/lC_curl_h.jl
@@ -3,21 +3,21 @@
 
 @c Cint curl_strequal (Ptr{UInt8}, Ptr{UInt8}) libcurl
 @c Cint curl_strnequal (Ptr{UInt8}, Ptr{UInt8}, size_t) libcurl
-@c CURLFORMcode curl_formadd (Ptr{Ptr{Void}}, Ptr{Ptr{Void}}) libcurl
-@c Cint curl_formget (Ptr{Void}, Ptr{Void}, curl_formget_callback) libcurl
-@c Void curl_formfree (Ptr{Void},) libcurl
+@c CURLFORMcode curl_formadd (Ptr{Ptr{Nothing}}, Ptr{Ptr{Nothing}}) libcurl
+@c Cint curl_formget (Ptr{Nothing}, Ptr{Nothing}, curl_formget_callback) libcurl
+@c Nothing curl_formfree (Ptr{Nothing},) libcurl
 @c Ptr{UInt8} curl_getenv (Ptr{UInt8},) libcurl
 @c Ptr{UInt8} curl_version () libcurl
 @c Ptr{UInt8} curl_easy_escape (Ptr{CURL}, Ptr{UInt8}, Cint) libcurl
 @c Ptr{UInt8} curl_escape (Ptr{UInt8}, Cint) libcurl
 @c Ptr{UInt8} curl_easy_unescape (Ptr{CURL}, Ptr{UInt8}, Cint, Ptr{Cint}) libcurl
 @c Ptr{UInt8} curl_unescape (Ptr{UInt8}, Cint) libcurl
-@c Void curl_free (Ptr{Void},) libcurl
+@c Nothing curl_free (Ptr{Nothing},) libcurl
 @c CURLcode curl_global_init (Cint,) libcurl
 @c CURLcode curl_global_init_mem (Cint, curl_malloc_callback, curl_free_callback, curl_realloc_callback, curl_strdup_callback, curl_calloc_callback) libcurl
-@c Void curl_global_cleanup () libcurl
-@c Ptr{Void} curl_slist_append (Ptr{Void}, Ptr{UInt8}) libcurl
-@c Void curl_slist_free_all (Ptr{Void},) libcurl
+@c Nothing curl_global_cleanup () libcurl
+@c Ptr{Nothing} curl_slist_append (Ptr{Nothing}, Ptr{UInt8}) libcurl
+@c Nothing curl_slist_free_all (Ptr{Nothing},) libcurl
 @c time_t curl_getdate (Ptr{UInt8}, Ptr{time_t}) libcurl
 @c Ptr{CURLSH} curl_share_init () libcurl
 @c CURLSHcode curl_share_setopt (Ptr{CURLSH}, CURLSHoption) libcurl
@@ -29,12 +29,12 @@
 @c Ptr{CURL} curl_easy_init () libcurl
 @c CURLcode curl_easy_setopt (Ptr{CURL}, CURLoption) libcurl
 @c CURLcode curl_easy_perform (Ptr{CURL},) libcurl
-@c Void curl_easy_cleanup (Ptr{CURL},) libcurl
+@c Nothing curl_easy_cleanup (Ptr{CURL},) libcurl
 @c CURLcode curl_easy_getinfo (Ptr{CURL}, CURLINFO) libcurl
 @c Ptr{CURL} curl_easy_duphandle (Ptr{CURL},) libcurl
-@c Void curl_easy_reset (Ptr{CURL},) libcurl
-@c CURLcode curl_easy_recv (Ptr{CURL}, Ptr{Void}, size_t, Ptr{size_t}) libcurl
-@c CURLcode curl_easy_send (Ptr{CURL}, Ptr{Void}, size_t, Ptr{size_t}) libcurl
+@c Nothing curl_easy_reset (Ptr{CURL},) libcurl
+@c CURLcode curl_easy_recv (Ptr{CURL}, Ptr{Nothing}, size_t, Ptr{size_t}) libcurl
+@c CURLcode curl_easy_send (Ptr{CURL}, Ptr{Nothing}, size_t, Ptr{size_t}) libcurl
 @c Ptr{CURLM} curl_multi_init () libcurl
 @c CURLMcode curl_multi_add_handle (Ptr{CURLM}, Ptr{CURL}) libcurl
 @c CURLMcode curl_multi_remove_handle (Ptr{CURLM}, Ptr{CURL}) libcurl
@@ -48,5 +48,5 @@
 @c CURLMcode curl_multi_socket_all (Ptr{CURLM}, Ptr{Cint}) libcurl
 @c CURLMcode curl_multi_timeout (Ptr{CURLM}, Ptr{Cint}) libcurl
 @c CURLMcode curl_multi_setopt (Ptr{CURLM}, CURLMoption) libcurl
-@c CURLMcode curl_multi_assign (Ptr{CURLM}, curl_socket_t, Ptr{Void}) libcurl
+@c CURLMcode curl_multi_assign (Ptr{CURLM}, curl_socket_t, Ptr{Nothing}) libcurl
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 using LibCURL
-using Compat
 
 # Just testing loading of the library and a simple library call.
 curl = curl_easy_init()


### PR DESCRIPTION
I have done some changes to bump this package to Julia 1.0.

I have translated all the `type` declarations into `mutable struct`, so instances of those types can be modified. Maybe some of those can be declared just `struct`. I am not very familiar with the code, so I am not sure of how each one of those types are used.

Lots of packages depend on this one, and are currently uninstallable on Julia 1.0; merging this PR will make it possible to install those packages.