### PR TITLE
WIP: Add ability to find the system CACert or explicitly define one yourself

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1)
 function curl_write_cb(curlbuf::Ptr{Void}, s::Csize_t, n::Csize_t, p_ctxt::Ptr{Void})
     sz = s * n
     data = Array{UInt8}(sz)
-    
+
     ccall(:memcpy, Ptr{Void}, (Ptr{Void}, Ptr{Void}, UInt64), data, curlbuf, sz)
     println("recd: ", String(data))
-    
+
     sz::Csize_t
 end
 
@@ -54,4 +54,31 @@ println("httpcode : ", http_code)
 # release handle
 curl_easy_cleanup(curl)
 
+```
+
+### Using CACerts for SSL/TLS Authentication
+
+If you want LibCURL to attempt to find a system CACert you can run:
+
+```julia
+# find_system_cert will return either a CACertFile or a CACertPath depending on
+# what kind of system certificate(s) it finds.
+# This function will return nothing if it can't find any system certificates
+cacert = find_system_cacert()
+
+if cacert !== nothing
+    enable_cacert(curl, cacert)
+end
+```
+
+You can also specify your own cacert if need be.
+
+```julia
+# You can either specify a specific certificate file
+cacert = CACertFile("path/to/cert.pem")
+enable_cacert(curl, cacert)
+
+# Or you can specify a folder that contains certificates
+cacert = CACertPath("path/to/certs")
+enable_cacert(curl, cacert)
 ```

--- a/src/LibCURL.jl
+++ b/src/LibCURL.jl
@@ -10,6 +10,7 @@ const curl_off_t = Int64
 const fd_set = Union{}
 const socklen_t = Int32
 
+export find_system_cacert, enable_cacert, CACertFile, CACertPath
 
 # Load libcurl libraries from our deps.jl
 const depsjl_path = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
@@ -21,6 +22,8 @@ include(depsjl_path)
 function __init__()
     check_deps()  # Always check your dependencies from `deps.jl`
 end
+
+include("cert.jl")
 
 include("lC_exports_h.jl")
 include("lC_common_h.jl")

--- a/src/cert.jl
+++ b/src/cert.jl
@@ -1,0 +1,75 @@
+# Possible certificate files; stop after finding one
+const cert_files = [
+    # Debian/Ubuntu/Gentoo etc.
+    "/etc/ssl/certs/ca-certificates.crt",
+    # Fedora/RHEL 6
+    "/etc/pki/tls/certs/ca-bundle.crt",
+    # OpenSUSE
+    "/etc/ssl/ca-bundle.pem",
+    # OpenELEC
+    "/etc/pki/tls/cacert.pem",
+    # CentOS/RHEL 7
+    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+    # macOS (OpenSSL Bomebrew Install)
+    "/usr/local/etc/openssl/cert.pem",
+    # macOS
+    "/etc/ssl/cert.pem",
+]
+
+# Possible directories with certificate files; stop afer successfully reading at least
+# one file from a directory
+const cert_directories = [
+    # SLES10/SLES11
+    "/etc/ssl/certs/",
+    # Android
+    "/system/etc/security/cacerts",
+    # FreeBSD
+    "/usr/local/share/certs",
+    # Fedora/RHEL
+    "/etc/pki/tls/certs",
+    # NetBSD
+    "/etc/openssl/certs",
+    # AIX
+    "/var/ssl/certs",
+]
+
+struct CACertFile
+    path::AbstractString
+    CACertFile(path::AbstractString) = new(path)
+end
+
+struct CACertPath
+    path::AbstractString
+    CACertPath(path::AbstractString) = new(path)
+end
+
+function find_system_cacert()
+    # Check if a cert file exists
+    for f in cert_files
+        if isfile(f)
+            # If a cert location exists, return it
+            return CACertFile(f)
+        end
+    end
+
+    # Check if a cert directory exists and has files in it
+    for f in cert_directories
+        if isdir(f)
+            dirfiles = readdir(f)
+            if length(dirfiles) > 0
+                return CACertPath(f)
+            end
+        end
+    end
+
+    # If we didn't find any system certs, return Nothing
+    return nothing
+end
+
+function enable_cacert(handle, cert::CACertFile)
+    curl_easy_setopt(handle, CURLOPT_CAINFO, cert.path)
+end
+
+function enable_cacert(handle, cert::CACertPath)
+    curl_easy_setopt(handle, CURLOPT_CAPATH, cert.path)
+end

--- a/src/cert.jl
+++ b/src/cert.jl
@@ -33,16 +33,35 @@ const cert_directories = [
     "/var/ssl/certs",
 ]
 
+"""
+    CACertFile
+
+The `CACertFile` type represents a path to a `.pem` or `.crt` file to be used as a
+Certificate Authority Certificate for SSL/TLS requests.
+"""
 struct CACertFile
     path::AbstractString
     CACertFile(path::AbstractString) = new(path)
 end
 
+"""
+    CACertPath
+
+The `CACertPath` type represents a path to a directory containing `.pem` or `.crt` files
+to be used as Certificate Authority Certificates for SSL/TLS requests.
+"""
 struct CACertPath
     path::AbstractString
     CACertPath(path::AbstractString) = new(path)
 end
 
+"""
+    find_system_cacert() -> Union{CACertFile, CACertPath, Nothing}
+
+Search the filesystem for common locations of installed Certificate Authority Certificates.
+Will return a `CACertFile` if a specific file is found, or a `CACertPath` if a specific
+directory contains certificates is found. Will return `nothing` if nothing is found.
+"""
 function find_system_cacert()
     # Check if a cert file exists
     for f in cert_files
@@ -66,10 +85,20 @@ function find_system_cacert()
     return nothing
 end
 
+"""
+    enable_cacert(handle, cert::CACertFile)
+
+Apply the `CACertFile` path to the `CURLOPT_CAINFO` argument of the passed in `curl` handle.
+"""
 function enable_cacert(handle, cert::CACertFile)
     curl_easy_setopt(handle, CURLOPT_CAINFO, cert.path)
 end
 
+"""
+    enable_cacert(handle, cert::CACertPath)
+
+Apply the `CACertPath` path to the `CURLOPT_CAPATH` argument of the passed in `curl` handle.
+"""
 function enable_cacert(handle, cert::CACertPath)
     curl_easy_setopt(handle, CURLOPT_CAPATH, cert.path)
 end

--- a/test/ssl.jl
+++ b/test/ssl.jl
@@ -1,3 +1,5 @@
+using Compat
+
 # Test that https://www.google.com successfully connects
 curl = curl_easy_init()
 curl == C_NULL && error("curl_easy_init() failed")

--- a/test/ssl.jl
+++ b/test/ssl.jl
@@ -34,9 +34,12 @@ end
 
     @testset "Success: find_system_cert" begin
         cacert = find_system_cacert()
-        enable_cacert(curl, cacert)
-        res = curl_easy_perform(curl)
-        @test res == CURLE_OK
+        # There is no guarantee that it will find a system cert
+        if cacert !== nothing
+            enable_cacert(curl, cacert)
+            res = curl_easy_perform(curl)
+            @test res == CURLE_OK
+        end
     end
 end
 

--- a/test/ssl.jl
+++ b/test/ssl.jl
@@ -2,14 +2,40 @@
 curl = curl_easy_init()
 curl == C_NULL && error("curl_easy_init() failed")
 
+# Setup the callback function to recv data
+function curl_write_cb(curlbuf::Ptr{Cvoid}, s::Csize_t, n::Csize_t, p_ctxt::Ptr{Cvoid})
+    sz = s * n
+    data = Array{UInt8}(undef, sz)
+
+    ccall(:memcpy, Ptr{Cvoid}, (Ptr{Cvoid}, Ptr{Cvoid}, UInt64), data, curlbuf, sz)
+
+    sz::Csize_t
+end
+
 @testset "SSL: https://www.google.com" begin
+    c_curl_write_cb = @cfunction(
+        curl_write_cb,
+        Csize_t,
+        (Ptr{Cvoid}, Csize_t, Csize_t, Ptr{Cvoid})
+    )
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, c_curl_write_cb)
+
     curl_easy_setopt(curl, CURLOPT_URL, "https://www.google.com")
     curl_easy_setopt(curl, CURLOPT_USE_SSL, CURLUSESSL_ALL)
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2)
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1)
 
-    res = curl_easy_perform(curl)
-    @test res == CURLE_OK
+    @testset "Failure: no cacert" begin
+        res = curl_easy_perform(curl)
+        @test res != CURLE_OK
+    end
+
+    @testset "Success: find_system_cert" begin
+        cacert = find_system_cacert()
+        enable_cacert(curl, cacert)
+        res = curl_easy_perform(curl)
+        @test res == CURLE_OK
+    end
 end
 
 curl_easy_cleanup(curl)

--- a/test/ssl.jl
+++ b/test/ssl.jl
@@ -1,0 +1,15 @@
+# Test that https://www.google.com successfully connects
+curl = curl_easy_init()
+curl == C_NULL && error("curl_easy_init() failed")
+
+@testset "SSL: https://www.google.com" begin
+    curl_easy_setopt(curl, CURLOPT_URL, "https://www.google.com")
+    curl_easy_setopt(curl, CURLOPT_USE_SSL, CURLUSESSL_ALL)
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2)
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1)
+
+    res = curl_easy_perform(curl)
+    @test res == CURLE_OK
+end
+
+curl_easy_cleanup(curl)


### PR DESCRIPTION
This PR defines two new functions, two lists, and two types.

Two consts: `cert_files` and `cert_directories` which contain paths to the most common locations for Certificate Authority Certificates on various OS types.

Since LibCURL isn't compiled to naturally know where the certs are on any given machine, I have written `find_system_cacert` as a way to search for a system cert based on known locations on various OS's/installations

2 new types have been created for this. `CACertFile` which contains a string that defines a path to a specific pem/crt file, and `CACertPath` which contains a string that defines a path to a directory that contains pem/crt files. I decided to use two different types as there are 2 different commands in LibCURL to set the file path vs the directory path, and thus by using these types we can leverage multiple dispatch to use the correct function.

`find_system_cacert` will return a `CACertFile` or a `CACertPath` depending on what location it finds the certs in. If it can't seem to find any system certs at all, it will return with `nothing`, and the user must check against it returning nothing and handle the errors themselves.

On top of this, I have defined `enable_cacert` which is a function that takes in a curl `handle` and either a `CACertFile` or `CACertPath` and applies the path using the correct LibCURL function to the handle so that any future requests with that handle will use the certificate that was found.

