### PR TITLE
Structure the tests and add an ssl test

### DIFF
--- a/test/ssl.jl
+++ b/test/ssl.jl
@@ -15,7 +15,7 @@ function curl_write_cb(curlbuf::Ptr{Cvoid}, s::Csize_t, n::Csize_t, p_ctxt::Ptr{
     sz::Csize_t
 end
 
-@testset "SSL: https://www.google.com" begin
+@testset "SSL verify" begin
     # Set up the write function to consume the curl output so we don't see it in the
     # test output
     c_curl_write_cb = @cfunction(

--- a/test/ssl.jl
+++ b/test/ssl.jl
@@ -1,4 +1,5 @@
 using Compat
+using Compat.Sys: isapple, iswindows
 
 # Test that https://www.google.com successfully connects
 curl = curl_easy_init()
@@ -35,7 +36,7 @@ end
         # NOTE: This will fail on macOS due to the cross compilation not knowing where the
         # macOS CACerts would be
         # The same issue would exist with Windows as well
-        if Sys.isapple() || Sys.windows()
+        if isapple() || iswindows()
             @test_broken res == CURLE_OK
         else
             @test res == CURLE_OK

--- a/test/ssl.jl
+++ b/test/ssl.jl
@@ -1,0 +1,43 @@
+using Compat
+
+# Test that https://www.google.com successfully connects
+curl = curl_easy_init()
+curl == C_NULL && error("curl_easy_init() failed")
+
+# Setup the callback function to recv data
+function curl_write_cb(curlbuf::Ptr{Cvoid}, s::Csize_t, n::Csize_t, p_ctxt::Ptr{Cvoid})
+    sz = s * n
+    data = Array{UInt8}(undef, sz)
+
+    ccall(:memcpy, Ptr{Cvoid}, (Ptr{Cvoid}, Ptr{Cvoid}, UInt64), data, curlbuf, sz)
+
+    sz::Csize_t
+end
+
+@testset "SSL: https://www.google.com" begin
+    # Set up the write function to consume the curl output so we don't see it in the
+    # test output
+    c_curl_write_cb = @cfunction(
+        curl_write_cb,
+        Csize_t,
+        (Ptr{Cvoid}, Csize_t, Csize_t, Ptr{Cvoid})
+    )
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, c_curl_write_cb)
+
+    # Set up our SSL options
+    curl_easy_setopt(curl, CURLOPT_URL, "https://www.google.com")
+    curl_easy_setopt(curl, CURLOPT_USE_SSL, CURLUSESSL_ALL)
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2)
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1)
+
+    @testset "SSL Success" begin
+        res = curl_easy_perform(curl)
+        # NOTE: This will fail on macOS due to the cross compilation not knowing where the
+        # macOS CACerts would be
+        # The same issue would exist with Windows as well
+        @test res == CURLE_OK
+    end
+
+end
+
+curl_easy_cleanup(curl)

--- a/test/ssl.jl
+++ b/test/ssl.jl
@@ -35,7 +35,11 @@ end
         # NOTE: This will fail on macOS due to the cross compilation not knowing where the
         # macOS CACerts would be
         # The same issue would exist with Windows as well
-        @test res == CURLE_OK
+        if Sys.isapple() || Sys.windows()
+            @test_broken res == CURLE_OK
+        else
+            @test res == CURLE_OK
+        end
     end
 
 end


### PR DESCRIPTION
As we still don't really have a good solution for https://github.com/JuliaWeb/LibCURL.jl/pull/57 this PR simply adds a test to check if an SSL connection connects. 

The other tests have been structured a little different as well for consistency. 

NOTE: This will fail on macOS and Windows, and this is a known issue due to how LibCURL won't know where the system certs exist on macOS and Windows. 