### PR TITLE
Remove REQUIRE file

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 0.7
-BinaryProvider 0.3


### PR DESCRIPTION
Should have been removed when Julia 0.6 was dropped.