### PR TITLE
Fix system image incompatibility with `LibCURL.cacert`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibCURL"
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 LibCURL_jll = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"

--- a/src/LibCURL.jl
+++ b/src/LibCURL.jl
@@ -16,7 +16,7 @@ export Mime_ext
 
 function __init__()
     # Note: `MozillaCACerts_jll.cacert` is filled by `__init__` which requires LibCURL's
-    # copy to also be filled in during initialization. Doing this ensures that compatibility
+    # copy to also be filled in during initialization. Doing this ensures compatibility
     # with building system images.
     global cacert = MozillaCACerts_jll.cacert
 end

--- a/src/LibCURL.jl
+++ b/src/LibCURL.jl
@@ -10,9 +10,16 @@ const curl_off_t = Int64
 const fd_set = Union{}
 const socklen_t = Int32
 
-const cacert = MozillaCACerts_jll.cacert
+cacert = ""
 
 export Mime_ext
+
+function __init__()
+    # Note: `MozillaCACerts_jll.cacert` is filled by `__init__` which requires LibCURL's
+    # copy to also be filled in during initialization. Doing this ensures that compatibility
+    # with building system images.
+    global cacert = MozillaCACerts_jll.cacert
+end
 
 include("lC_exports_h.jl")
 include("lC_common_h.jl")


### PR DESCRIPTION
When attempting to reference `LibCURL.cacert` from within a system image the returned path would be `""` as this is what [MozillaCACerts_jll stores before initialization](https://github.com/JuliaBinaryWrappers/MozillaCACerts_jll.jl/blob/master/src/wrappers/any.jl#L18).