### PR TITLE
tests: use Downloads.download instead of Base.download

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,8 @@ MozillaCACerts_jll = ">= 2020"
 julia = "1.3"
 
 [extras]
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Downloads", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,7 @@ using Test
 
         @testset "system curl" begin
             try
-                run(`curl -g -L -f -o $filename $url`)
+                run(`curl -s -g -L -f -o $filename $url`)
                 @test isfile(filename)
             finally
                 rm(filename; force=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
-using LibCURL
 using Test
+using LibCURL
+using Downloads: download
 
 # Just testing loading of the library and a simple library call.
 


### PR DESCRIPTION
Base.download will be deprecated in Julia 1.6 but the Downloads package
offers a consistent libcurl-based way to download instead.