### PR TITLE
adjust LibCURL_jll compat to 7.66

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ LibCURL_jll = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
 MozillaCACerts_jll = "14a3606d-f60d-562e-9121-12d972cd8159"
 
 [compat]
-LibCURL_jll = "7.68"
+LibCURL_jll = "7.66"
 MozillaCACerts_jll = ">= 2020"
 julia = "1.3"
 


### PR DESCRIPTION
This is the actual version of libcurl that's shipped with several
versions of Julia, so requiring a higher version is wrongn and
has started causing resolver problems now that we're telling the
truth about Julia's actual libcurl version.