### PR TITLE
[doc] add index file

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,4 @@
+# LibCURL
+
+This is a simple Julia wrapper around http://curl.haxx.se/libcurl/ generated using [Clang.jl](https://github.com/ihnorton/Clang.jl). 
+Please see the [libcurl API documentation](https://curl.haxx.se/libcurl/c/) for help on how to use this package.


### PR DESCRIPTION
xref: JuliaLang/julia#38462

Should we move the examples from the readme to the docs?


