### PR TITLE
Use concrete types in `MimeExt`

### DIFF
--- a/src/Mime_ext.jl
+++ b/src/Mime_ext.jl
@@ -2,7 +2,7 @@ module Mime_ext
 
 export MimeExt
 
-MimeExt = Dict{AbstractString,AbstractString}(
+MimeExt = Dict{String,String}(
     "ez" => "application/andrew-inset",
     "anx" => "application/annodex",
     "atom" => "application/atom+xml",


### PR DESCRIPTION
Code generated to work on this Dict shows up as a minor source
of invalidation when loading packages that define new
`AbstractString` types.