### PR TITLE
Allow LibCURL_jll 8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "LibCURL"
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 LibCURL_jll = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
 MozillaCACerts_jll = "14a3606d-f60d-562e-9121-12d972cd8159"
 
 [compat]
-LibCURL_jll = "7.66"
+LibCURL_jll = "7.66, 8"
 MozillaCACerts_jll = ">= 2020"
 julia = "1.3"
 


### PR DESCRIPTION
The new series is completely API/ABI-compatible with version 7, the major version was bumped just to celebrate the 25th anniversary